### PR TITLE
Fixed brunch watcher on Windows

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,7 @@ config :talon_demo, TalonDemo.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [node: ["node_modules/.bin/brunch", "watch", "--stdin",
+  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
                     cd: Path.expand("../", __DIR__)]]
 
 


### PR DESCRIPTION
Fixes the error in #1.
It works on a linux VM and I don't have a way to test it on a Mac   